### PR TITLE
Tweaks to comply with Cambridge BGS regs 2020

### DIFF
--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -227,8 +227,9 @@ footnotes.}
 % Declare new Boolean variable to allow separate toggle 
 % to include author name and title in abstract,
 % i.e. Cambridge BGS style
-\newif\ifntabstract\ntabstractfalse
+\newif\ifntabstract\ntabstracttrue
 \DeclareOption{ntabstract}{\ntabstracttrue}
+\DeclareOption{nontabstract}{\ntabstractfalse}
 
 % Generates Warning for unknown options
 \DeclareOption*{
@@ -1143,7 +1144,8 @@ wish to left align your text}
     {{\large \vspace*{1em} \@author} \par}
   \end{center}
 \else
-% Normal abstract in the thesis
+% Normal abstract in the thesis,
+% toggled by nontabstract option
   \cleardoublepage
   \setsinglecolumn
   \chapter*{\centering \Large \@abstracttitle}

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -631,8 +631,6 @@ supported!}
 	  % body space per page
      \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
 	  vmarginratio=1:1,vscale=0.75,width=157mm,bindingoffset=5mm]{geometry}  
-%    \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
-%      vmarginratio=1:1,scale=0.75,bindingoffset=5mm]{geometry}
   \fi
 
   \if@twoside
@@ -668,8 +666,6 @@ supported!}
       % body space per page
       \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
         vmarginratio=1:1,vscale=0.75,width=157mm]{geometry} % dvips
-%      \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
-%        vmarginratio=1:1,scale=0.75]{geometry} % dvips
     \fi
     \hypersetup{pdfpagelayout=OneColumn}
 \fi

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -1125,9 +1125,6 @@ wish to left align your text}
     \renewcommand{\printthesisindex}{}
     \renewcommand{\bibname}{}
     \renewcommand{\bibliography}[1]{\thispagestyle{empty}}
-    
-    % Turn on name and title on abstract (DYC 2020)
-    \ntabstracttrue
 \else
     \defineAbstractfalse
 \fi

--- a/PhDThesisPSnPDF.cls
+++ b/PhDThesisPSnPDF.cls
@@ -4,15 +4,15 @@
 %%                                                                            %%
 %% A PhD thesis LaTeX template for Cambridge University Engineering Department%%
 %%                                                                            %%
-%% Version: v2.4                                                              %%
+%% Version: v2.5                                                              %%
 %% Authors: Krishna Kumar                                                     %%
 %% License: MIT License (c) 2016-2018 Krishna Kumar                           %%
 %% GitHub Repo: https://github.com/kks32/phd-thesis-template/                 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % ************************** Class Identification ******************************
-\newcommand\fileversion{2.4}
-\newcommand\filedate{2018/04/12}
+\newcommand\fileversion{2.5}
+\newcommand\filedate{2020/12/02}
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{PhDThesisPSnPDF}[\filedate\space A PhD thesis class file
  by Krishna Kumar (v\fileversion)]
@@ -224,6 +224,11 @@ footnotes.}
 \DeclareOption{lineno}{\PHD@linenotrue}
 \DeclareOption{nolineno}{\PHD@linenofalse}
 
+% Declare new Boolean variable to allow separate toggle 
+% to include author name and title in abstract,
+% i.e. Cambridge BGS style
+\newif\ifntabstract\ntabstractfalse
+\DeclareOption{ntabstract}{\ntabstracttrue}
 
 % Generates Warning for unknown options
 \DeclareOption*{
@@ -622,8 +627,12 @@ supported!}
   \ifsetCustomMargin
   % Margin to be define in preamble using geometry package
   \else
-    \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
-      vmarginratio=1:1,scale=0.75,bindingoffset=5mm]{geometry}
+      % Edited DYC 2020 so print and online versions have the same
+	  % body space per page
+     \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
+	  vmarginratio=1:1,vscale=0.75,width=157mm,bindingoffset=5mm]{geometry}  
+%    \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
+%      vmarginratio=1:1,scale=0.75,bindingoffset=5mm]{geometry}
   \fi
 
   \if@twoside
@@ -655,8 +664,12 @@ supported!}
     % Margin to be define in preamble using geometry package
     \else
       % No Margin staggering on Odd and Even side
+      % Edited DYC 2020 so print and online versions have the same
+      % body space per page
       \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
-        vmarginratio=1:1,scale=0.75]{geometry} % dvips
+        vmarginratio=1:1,vscale=0.75,width=157mm]{geometry} % dvips
+%      \RequirePackage[paper=\PHD@papersize,hmarginratio=1:1,
+%        vmarginratio=1:1,scale=0.75]{geometry} % dvips
     \fi
     \hypersetup{pdfpagelayout=OneColumn}
 \fi
@@ -1102,10 +1115,11 @@ wish to left align your text}
 % The abstract environment puts a large, bold, centered "Abstract" label at
 % the top of the page. Defines both abstract and separate abstract environment
 
-% To include only the Title and the abstract pages for submission to BoGS
+% To include only the abstract pages for submission to BoGS
 \ifPHD@abstract
     \defineAbstracttrue
-    % Disable the table of contents, figures, tables, index and nomenclature
+    % Disable the title, table of contents, figures, tables, index and nomenclature
+    \renewcommand{\maketitle}{} % Added by DYC 2020
     \renewcommand{\tableofcontents}{}
     \renewcommand{\listoffigures}{}
     \renewcommand{\listoftables}{}
@@ -1114,14 +1128,18 @@ wish to left align your text}
     \renewcommand{\printthesisindex}{}
     \renewcommand{\bibname}{}
     \renewcommand{\bibliography}[1]{\thispagestyle{empty}}
+    
+    % Turn on name and title on abstract (DYC 2020)
+    \ntabstracttrue
 \else
     \defineAbstractfalse
 \fi
 
-
 \newenvironment{abstract} {
-\ifPHD@abstract
-% Separate abstract as per Student Registry guidelines
+\ifntabstract
+% Print name and title on abstract, whether when
+% abstract is standalone or toggled by ntabstract option
+% (per Student Registry guidelines)
   \thispagestyle{empty}
   \setsinglecolumn
   \begin{center}

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ It supports the following custom options in the documentclass in thesis.tex:
 
 *   `abstract`: This option enables only the thesis title page and the abstract with title and author to be printed.
 
+*   `nontabstract`: This option prints the heading "Abstract" rather than your name and thesis title onto the abstract page of your thesis when the whole thesis is compiled.
+
 *   `chapter`: This option enables only the specified chapter and it's references. Useful for review and corrections.
 
 *   `draft`: The default draft mode supports some special features such as line numbers, images, and water mark with

--- a/thesis.tex
+++ b/thesis.tex
@@ -31,9 +31,8 @@
 % `abstract': To generate only the title page and abstract page with
 % dissertation title and name, to submit to the Student Registry
 %
-% `ntabstract': To add name and title to abstract page 
-% even when bound into thesis (required by Cambridge Uni
-% hardbound submission)
+% `nontabstract': To remove name and title from abstract page 
+% when bound into thesis
 %
 % `chapter`: This option enables only the specified chapter and it's references
 %  Useful for review and corrections.

--- a/thesis.tex
+++ b/thesis.tex
@@ -31,6 +31,10 @@
 % `abstract': To generate only the title page and abstract page with
 % dissertation title and name, to submit to the Student Registry
 %
+% `ntabstract': To add name and title to abstract page 
+% even when bound into thesis (required by Cambridge Uni
+% hardbound submission)
+%
 % `chapter`: This option enables only the specified chapter and it's references
 %  Useful for review and corrections.
 %
@@ -87,13 +91,13 @@
 \input{thesis-info}
 
 % ***************************** Abstract Separate ******************************
-% To printout only the titlepage and the abstract with the PhD title and the
+% To printout only the abstract with the PhD title and the
 % author name for submission to the Student Registry, use the `abstract' option in
 % the document class.
 
 \ifdefineAbstract
  \pagestyle{empty}
- \includeonly{Declaration/declaration, Abstract/abstract}
+ \includeonly{Abstract/abstract}
 \fi
 
 % ***************************** Chapter Mode ***********************************
@@ -104,6 +108,8 @@
 
 \ifdefineChapter
  \includeonly{Chapter3/chapter3}
+% You can put multiple files into this command, e.g.
+% \includeonly{Declaration/declaration, Chapter3/chapter3}
 \fi
 
 % ******************************** Front Matter ********************************
@@ -115,8 +121,8 @@
 
 \include{Dedication/dedication}
 \include{Declaration/declaration}
-\include{Acknowledgement/acknowledgement}
 \include{Abstract/abstract}
+\include{Acknowledgement/acknowledgement}
 
 % *********************** Adding TOC and List of Figures ***********************
 
@@ -126,10 +132,8 @@
 
 \listoftables
 
-% \printnomenclature[space] space can be set as 2em between symbol and description
-%\printnomenclature[3em]
-
-\printnomenclature
+% \printnomencl[space] space can be set as 2em between symbol and description
+\printnomencl[3em]
 
 % ******************************** Main Matter *********************************
 \mainmatter
@@ -167,7 +171,9 @@
 % specified in the preamble.tex file in the custombib section.
 % Comment out the lines related to natbib above and uncomment the following line.
 
-%\printbibliography[heading=bibintoc, title={References}]
+%\ifdefineAbstract\else \printbibliography[heading=bibintoc, title={References}] \fi
+% The if command on the previous line is required because 
+% biber package is invoked after calling the class definition
 
 
 \end{spacing}


### PR DESCRIPTION
Hardbound thesis submission formatting requirements from Cambridge University Board of Graduate Studies have changed since this template was last updated in 2018. Some of the changes could not be satisfied without modifying the class file, so this patch tweaked some details to provide functionality to comply with the latest Cambridge regulations.

Changes include:
- `abstract' option (abstract-only mode) now hides title page, nomenclature, and references as well (class file and thesis.tex)
- New class option `ntabstract' to print name and title onto abstract even when bound into the whole thesis (class file)
- Abstract now comes before Acknowledgements (thesis.tex)
- Default horizontal margins now defined using `width' rather than `ratio', so that bindingoffset no longer causes print and web editions to have different pagination. (class file)

I can update CHANGELOG and README as well if this pull request is committed into the master branch.